### PR TITLE
feat(core): upgrade models to UUIDv7 and add GIN index to properties

### DIFF
--- a/apps/gearpit-core/internal/domain/models.go
+++ b/apps/gearpit-core/internal/domain/models.go
@@ -10,13 +10,14 @@ import (
 
 // Item:
 type Item struct {
-	ID           string `json:"id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	ID           string `json:"id" gorm:"primaryKey;type:uuid"`
 	Name         string `json:"name" gorm:"not null"`
 	Brand        string `json:"brand"`
 	WeightGram   int    `json:"weightGram"`
 	IsConsumable bool   `json:"isConsumable"`
 
-	Properties map[string]any `json:"properties,omitempty" gorm:"type:jsonb;serializer:json"`
+	// JSONB検索用にGINインデックスを追加
+	Properties map[string]any `json:"properties,omitempty" gorm:"type:jsonb;serializer:json;index:type:gin"`
 
 	Tags pq.StringArray `json:"tags" gorm:"type:text[]"`
 
@@ -28,7 +29,7 @@ type Item struct {
 
 // Kit:
 type Kit struct {
-	ID   string `json:"id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	ID   string `json:"id" gorm:"primaryKey;type:uuid"`
 	Name string `json:"name" gorm:"not null"`
 
 	ItemIDs pq.StringArray `json:"itemIds" gorm:"type:text[]"`
@@ -39,7 +40,7 @@ type Kit struct {
 
 // Loadout
 type Loadout struct {
-	ID          string        `json:"id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	ID          string        `json:"id" gorm:"primaryKey;type:uuid"`
 	Name        string        `json:"name" gorm:"not null"`
 	Items       []LoadoutItem `json:"items" gorm:"serializer:json"`
 	TotalWeight int           `json:"totalWeightGram"`
@@ -53,23 +54,37 @@ type LoadoutItem struct {
 	IsChecked bool   `json:"isChecked"`
 }
 
+// BeforeCreate Hooks: UUID v7への切り替え
+
 func (i *Item) BeforeCreate(tx *gorm.DB) (err error) {
 	if i.ID == "" {
-		i.ID = uuid.New().String()
+		id, err := uuid.NewV7()
+		if err != nil {
+			return err
+		}
+		i.ID = id.String()
 	}
 	return
 }
 
 func (k *Kit) BeforeCreate(tx *gorm.DB) (err error) {
 	if k.ID == "" {
-		k.ID = uuid.New().String()
+		id, err := uuid.NewV7()
+		if err != nil {
+			return err
+		}
+		k.ID = id.String()
 	}
 	return
 }
 
 func (l *Loadout) BeforeCreate(tx *gorm.DB) (err error) {
 	if l.ID == "" {
-		l.ID = uuid.New().String()
+		id, err := uuid.NewV7()
+		if err != nil {
+			return err
+		}
+		l.ID = id.String()
 	}
 	return
 }


### PR DESCRIPTION
- Change ID generation from DB default (gen_random_uuid/v4) to Go-side UUID v7 hook.
- Add GIN index to Item.Properties (JSONB) for efficient querying.
- Update BeforeCreate hooks for Item, Kit, and Loadout entities.

Ref: Phase-2 Data Model Hardening